### PR TITLE
feat/shellspec

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -11,3 +11,8 @@ files/
 {{/* skip apply .gitconfig on devcontainer */}}
 /.gitconfig
 {{- end }}
+
+{{/* shellspec */}}
+.shellspec*
+spec/
+**/*_spec.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,13 @@ jobs:
           aqua i -a
           make test
 
+  test:
+    name: make test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-install
+      - name: Run tests
+        shell: bash --login -eo pipefail {0} 
+        run: |
+          make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,14 @@ name: check
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  run-install:
+  run-install-test:
     strategy:
       matrix:
         distro: ["ubuntu", "debian"]
@@ -17,3 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/run-install
+      - run: |
+          echo "AQUA_GLOBAL_CONFIG=$HOME/.config/aquaproj-aqua/aqua.yaml" >> $GITHUB_ENV
+      - name: test
+        shell: bash --login -eo pipefail {0}
+        run: |
+          aqua i -a
+          make test
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,12 @@ repos:
     rev: v1.6.26
     hooks:
       - id: actionlint-system
+  - repo: local
+    hooks:
+      - id: make_test
+        name: "Make test"
+        language: system
+        entry: make test
+        files: '^.*/.*\.sh$'
+        pass_filenames: false
+

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,15 @@
+--require spec_helper
+
+--default-path "**/spec"
+--execdir @specfile
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,8 @@ copy_from_current:
 	@VSCODE_USER_SPACE=$$(wslpath "$$(wslvar APPDATA)/Code/User") \
 	&& test -f "$${VSCODE_USER_SPACE}/keybindings.json" && \
 		cp  "$${VSCODE_USER_SPACE}/keybindings.json" $(VSCODE_PATH)/keybindings.json || true
+
+.PHONY: test
+test:
+	@shellspec -s bash
+

--- a/dot_bash_profile
+++ b/dot_bash_profile
@@ -1,0 +1,9 @@
+# .bash_profile
+
+if [ -f ~/.profile ]; then
+    . ~/.profile
+fi
+
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -101,7 +101,7 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
     . /etc/bash_completion
 fi
 
-test -f $HOME/.local/bin/functions.sh && source $HOME/.local/bin/functions.sh
+test -f $HOME/.local/lib/functions.sh && source $HOME/.local/lib/functions.sh
 
 if [ -f $HOME/.local/bin/setup-socat-ssh-agent.sh ] && on_wsl2 && ! is_in_container; then
     source $HOME/.local/bin/setup-socat-ssh-agent.sh

--- a/dot_config/aquaproj-aqua/aqua.yaml
+++ b/dot_config/aquaproj-aqua/aqua.yaml
@@ -26,3 +26,4 @@ packages:
 - name: argoproj/argo-cd@v2.9.1
 - name: jdx/rtx@v2023.12.23
 - name: reviewdog/reviewdog@v0.15.0
+- name: shellspec/shellspec@0.28.1

--- a/dot_local/lib/functions.sh
+++ b/dot_local/lib/functions.sh
@@ -61,3 +61,25 @@ random_string() {
     LENGTH=${1:-32}
     cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $LENGTH | head -n 1
 }
+
+prepend_to_all() {
+    if [ $# -lt 2 ]; then
+        echo "Usage: ${0} <prefix> <string1> <string2> ..." >&2
+        return 1
+    fi
+
+    PREFIX="${1}"
+    shift 1
+    STRINGS=("$@")
+    printf -- "${PREFIX}%s" "${STRINGS[@]}"
+}
+
+super-linter () {
+    envs=(
+        RUN_LOCAL=true
+        DEFAULT_BRANCH=$(git branch --show-current)
+        VALIDATE_ALL_CODEBASE=false
+    )
+    envs_as_string=$(prepend_to_all ' -e ' "${envs[@]}")
+    docker run --rm ${envs_as_string} -v $(pwd):/tmp/lint ghcr.io/super-linter/super-linter:slim-latest $@
+}

--- a/dot_local/lib/spec/test_functions_spec.sh
+++ b/dot_local/lib/spec/test_functions_spec.sh
@@ -1,0 +1,46 @@
+# tests for dot_local/bin/functions.sh
+
+Describe 'functions.sh'
+    setup() { :; }
+    teardown() { :; }
+    BeforeEach 'setup'
+    AfterEach 'teardown'
+
+    Include ../functions.sh
+
+    Describe 'random_string()' 
+        It 'should return random string default length.'
+            When call random_string
+            The output should regexp '^[a-zA-Z0-9]{32}$'
+        End
+        It 'should return random string 8 length.'
+            When call random_string 8
+            The output should regexp '^[a-zA-Z0-9]{8}$'
+        End
+    End
+
+    Describe 'prepend_to_all()'
+        It 'should prepend strings with prefix.'
+            When call prepend_to_all ',' 'a' 'b' 'c'
+            The output should eq ',a,b,c'
+        End
+
+        It 'should prepend strings with prefix.'
+            params=(a b c)
+            When call prepend_to_all ',' "${params[@]}"
+            The output should eq ',a,b,c'
+        End
+        
+        It 'should prepend strings with prefix.'
+            params=(a b c)
+            When call prepend_to_all ' -f ' "${params[@]}"
+            The output should eq ' -f a -f b -f c'
+        End
+
+        It 'should prepend strings with prefix.'
+            params=(a b)
+            When call prepend_to_all '-e ' "${params[@]}"
+            The output should eq '-e a-e b'
+        End
+    End
+End

--- a/dot_profile.tmpl
+++ b/dot_profile.tmpl
@@ -22,10 +22,4 @@ export AQUA_GLOBAL_CONFIG=$HOME/.config/aquaproj-aqua/aqua.yaml
 export RTX_CONFIG_FILE=$HOME/.config/rtx/config-global.toml
 {{ end }}
 
-if [ "$BASH" ]; then
-  if [ -f ~/.bashrc ]; then
-    . ~/.bashrc
-  fi
-fi
-
 mesg n 2> /dev/null || true

--- a/run_once_after_install_cli.sh.tmpl
+++ b/run_once_after_install_cli.sh.tmpl
@@ -25,10 +25,11 @@ test -f "$(aqua root-dir)/bin/nvim" && rm "$(aqua root-dir)/bin/nvim"
 # install cli globally by aqua. aqua.yaml hash: {{ include "dot_config/aquaproj-aqua/aqua.yaml" | sha256sum }}
 export AQUA_GLOBAL_CONFIG=$HOME/.config/aquaproj-aqua/aqua.yaml
 aqua install --all
+export PATH="$(aqua root-dir)/bin:$PATH"
 
 # install cli globally by rtx. rtx/config-global.toml hash: {{ include "dot_config/rtx/config-global.toml" | sha256sum }}
 # change default env to avoid using in dev-containers as it may conflict with container tools.
-command -v rtx &>/dev/null && RTX_CONFIG_FILE=$HOME/.config/rtx/config-global.toml rtx install
+RTX_CONFIG_FILE=$HOME/.config/rtx/config-global.toml rtx install
 {{ end }}
 
 # misc

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  import 'support/custom_matcher'
+}

--- a/spec/support/custom_matcher.sh
+++ b/spec/support/custom_matcher.sh
@@ -1,0 +1,28 @@
+#shellcheck shell=bash
+# custom from https://github.com/shellspec/shellspec/blob/master/examples/spec/support/custom_matcher.sh
+shellspec_syntax 'shellspec_matcher_regexp'
+shellspec_syntax_alias 'shellspec_matcher_regex' 'shellspec_matcher_regexp'
+
+shellspec_matcher_regexp() {
+  shellspec_matcher__match() {
+    SHELLSPEC_EXPECT="$1"
+    [ "${SHELLSPEC_SUBJECT+x}" ] || return 1
+    # bash regex match operator
+    [[ $SHELLSPEC_SUBJECT =~ $SHELLSPEC_EXPECT ]] || return 1
+    return 0
+  }
+
+  # Message when the matcher fails with "should"
+  shellspec_matcher__failure_message() {
+    shellspec_putsn "expected: $1 match $2"
+  }
+
+  # Message when the matcher fails with "should not"
+  shellspec_matcher__failure_message_when_negated() {
+    shellspec_putsn "expected: $1 not match $2"
+  }
+
+  # checking for parameter count
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_do_match "$@"
+}

--- a/spec/test_custom_matcher_spec.sh
+++ b/spec/test_custom_matcher_spec.sh
@@ -1,0 +1,27 @@
+Describe 'custome_matcher.sh'
+    setup() { :; }
+    teardown() { :; }
+    BeforeEach 'setup'
+    AfterEach 'teardown'
+
+    Describe 'regexp'
+        It 'should regexp'
+            When call echo 'abc'
+            The output should regexp '[abc]{3}'
+        End
+        It 'should not regexp'
+            When call echo 'abc'
+            The output should not regexp '^[def]+$'
+        End
+    End
+    Describe 'regex alias'
+        It 'should regex'
+            When call echo 'abc'
+            The output should regex '[abc]{3}'
+        End
+        It 'should not regex'
+            When call echo 'abc'
+            The output should not regex '^[def]+$'
+        End
+    End
+End


### PR DESCRIPTION
- feat: add shellspec by aqua.
- feat: add make test by shellspec.
- feat: add shellspec files.
- feat: rename functions.sh and impl tests.
- fix: ignore tests for chezmoi.
- feat: add test with gha.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `chezmoiignore.tmpl`ファイルにShellspecテストファイルを無視するパターンを追加
  - `dot_actrc`ファイルを追加し、GitHub Actionsランナーのプラットフォーム設定を更新
  - `install.sh`スクリプトの`chezmoi init`コマンドに`--force`オプションを追加

- **バグ修正**
  - `.bashrc`のソースパスを正しいディレクトリに変更

- **ドキュメント**
  - `Makefile`にテストターゲットを追加

- **テスト**
  - Shellspecテストフレームワークのための設定ファイル`.shellspec`を追加
  - `functions.sh`ファイルのためのテストを追加
  - シェルスクリプトのカスタムマッチャーを追加

- **リファクタ**
  - `dot_profile.tmpl`からBashシェルチェックを削除してスクリプトロジックを簡素化

- **Chores**
  - CI設定にブランチ制限と新しいテストジョブを追加
  - ローカルフック"make_test"をプリコミット設定に追加

- **Revert**
  - 特になし
<!-- end of auto-generated comment: release notes by coderabbit.ai -->