### PR TITLE
chore/build essential mise

### DIFF
--- a/run_once_after_install_cli.sh.tmpl
+++ b/run_once_after_install_cli.sh.tmpl
@@ -29,7 +29,7 @@ export PATH="$(aqua root-dir)/bin:$PATH"
 
 # install cli globally by mise. mise/config-global.toml hash: {{ include "dot_config/mise/config-global.toml" | sha256sum }}
 # change default env to avoid using in dev-containers as it may conflict with container tools.
-MISE_CONFIG_FILE=$HOME/.config/mise/config-global.toml mise install
+MISE_JOBS=$(fgrep 'processor' /proc/cpuinfo | wc -l) MISE_CONFIG_FILE=$HOME/.config/mise/config-global.toml mise install
 {{ end }}
 
 # misc

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -14,6 +14,7 @@ sudo apt update && sudo apt install -y \
     lsof \
     inotify-tools \
     locales \
+    build-essential \
     ;
 
 {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu") }}


### PR DESCRIPTION
- chore: add build-essential
- chore: specify MISE_JOBS by processsors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- インストール時にプロセッサ数を指定できるように、CLIツールのグローバルインストールコマンドを改善しました。
- **改善点**
	- `build-essential` パッケージをインストールスクリプトに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->