### PR TITLE
feat: renovate.bot

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,9 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 
+[*.{json,json5}]
+indent_size = 2
+
 [{Makefile*,*.mk}]
 indent_style = tab
 

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,8 @@ test: clean
 watch-test:
 	/bin/bash -i -c 'watch_cmd "\.sh" "$(MAKE) test"'
 
+.PHONY: renovate
+renovate:
+	npx renovate --platform=local
+
 include $(MAKEFILE_DIR)mkfiles/*.mk

--- a/dot_default-npm-packages
+++ b/dot_default-npm-packages
@@ -1,3 +1,4 @@
 # mise nodejs
 @devcontainers/cli
 prettier
+renovate

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "github>aquaproj/aqua-renovate-config#1.13.0"
+  ],
+  "prConcurrentLimit": 10,
+  "enabledManagers": ["regex"], // update only aqua compoments.
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,5 @@
     "github>aquaproj/aqua-renovate-config#1.13.0"
   ],
   "prConcurrentLimit": 10,
-  "enabledManagers": ["regex"], // update only aqua compoments.
+  "enabledManagers": ["custom.regex"], // update only aqua compoments.
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `renovate` パッケージを既存の `mise`、`@devcontainers/cli`、`prettier` パッケージに追加しました。
- **リファクタ**
	- JSON および JSON5 ファイルのインデントサイズを2スペースに調整し、Makefile および .mk ファイルには4スペースを維持しました。
- **Chores**
	- ローカルプラットフォームで `npx renovate` を実行する新しい `.PHONY` ターゲット `renovate` を追加しました。
	- `renovate.json5` で特定のGitHubリポジトリからの設定を拡張し、同時に10個のPR制限を設定し、カスタムregexマネージャーを使用してAquaコンポーネントのみの更新を有効にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->