### PR TITLE
chore: enable auto-merge by renovate.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CodeOwners
+*   @air-hand

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,6 +4,7 @@
 [tools]
 poetry = {version='1.7.1'}
 python = {version='3.12.1', virtualenv='.venv'}
+node = {version='22'}
 
 [settings]
 experimental = true

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,5 +6,6 @@
   "enabledManagers": ["custom.regex"], // update only aqua compoments.
   "labels": [
     "dependencies",
-  ]
+  ],
+  "assigneesFromCodeOwners": true,
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,4 +4,7 @@
   ],
   "prConcurrentLimit": 10,
   "enabledManagers": ["custom.regex"], // update only aqua compoments.
+  "labels": [
+    "dependencies",
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,4 +8,19 @@
     "dependencies",
   ],
   "assigneesFromCodeOwners": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major"],
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["minor"],
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["patch"],
+      "automerge": true,
+    },
+  ]
 }

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,5 +1,5 @@
 config {
-  module = true
+  call_module_type = "local"
 }
 
 plugin "terraform" {

--- a/terraform/settings/labels.tf
+++ b/terraform/settings/labels.tf
@@ -1,0 +1,32 @@
+locals {
+  labels = [
+    {
+      name  = "dependencies"
+      color = "CCCCCC"
+    },
+    {
+      name  = "major"
+      color = "FF0000"
+    },
+    {
+      name  = "minor"
+      color = "00FF00"
+    },
+    {
+      name  = "patch"
+      color = "0000FF"
+    },
+  ]
+}
+
+resource "github_issue_labels" "dependencies" {
+  repository = data.github_repository.current.name
+
+  dynamic "label" {
+    for_each = local.labels
+    content {
+      name  = label.value.name
+      color = label.value.color
+    }
+  }
+}

--- a/terraform/shared/version.tf
+++ b/terraform/shared/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.2.0"
+      version = "6.2.2"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GitHubのissueラベルを作成する機能を追加しました。
  - 新しいCodeOwnersファイルを導入し、`@air-hand`がすべてのファイルの所有者として設定されました。
  - `.mise.toml`ファイルにNode.jsバージョン`22`を追加しました。
  - `renovate.json5`に新しいラベル、アサイン、パッケージ更新ルールの設定を追加しました。

- **バグ修正**
  - `terraform/.tflint.hcl`ファイルの設定を修正し、 `call_module_type` を `"local"` に変更しました。

- **その他**
  - `github`プロバイダのバージョンを `6.2.0` から `6.2.2` に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->