### PR TITLE
fix/remove aqua by brew

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,13 @@ jobs:
   run-install-vm:
     permissions: {}
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/run-install

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,12 +1,12 @@
 # https://github.com/jdx/mise#configuration
-[env]
-TERRAGRUNT_TFPATH = "tofu"
-
 [tools]
 poetry = {version='1.8.5'}
-python = {version='3.13.1', virtualenv='.venv'}
+python = {version='3.13.1'}
 node = {version='22'}
 
 [settings]
 experimental = true
-python_venv_auto_create = true
+
+[env]
+TERRAGRUNT_TFPATH = "tofu"
+#_.python.venv = { path = ".venv", create = true, python = "3.13.1" }

--- a/dot_config/mise/config-global.toml
+++ b/dot_config/mise/config-global.toml
@@ -1,3 +1,6 @@
+[env]
+#_.python.venv = { path = ".venv", create = true }
+
 [tools]
 python = ['3.13.1']
 go = ['1.23']
@@ -5,7 +8,5 @@ rust = 'stable'
 node = '22'
 
 [settings]
-legacy_version_file = true
 experimental = true
-python_venv_auto_create = true
 python_compile = true

--- a/run_once_after_install_cli.sh.tmpl
+++ b/run_once_after_install_cli.sh.tmpl
@@ -17,6 +17,15 @@ for inst in "${install_by_brew[@]}"; do
     brew install $inst
 done
 
+while read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^# ]] && continue
+    brew rm "$line" --force
+done < <(cat <<EOF
+aqua
+EOF
+)
+
 # install aqua
 if ! command -v aqua &>/dev/null; then
     curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.1/aqua-installer


### PR DESCRIPTION
- **fix: remove aqua if installed by brew.**
- **fix: revert unsupported python at mise.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- Pythonのバージョンが3.13.1から3.12に更新されました。
	- `run_once_after_install_cli.sh.tmpl`スクリプトに、`aqua`パッケージを削除する新しいセクションが追加されました。
	- CIワークフローの`run-install-vm`ジョブが、複数のUbuntuバージョンで実行できるようにマトリックス戦略を導入しました。
- **バグ修正**
	- なし
- **ドキュメント**
	- なし
- **リファクタリング**
	- なし
- **スタイル**
	- なし
- **テスト**
	- なし
- **雑務**
	- なし
- **リバート**
	- なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->