### PR TITLE
chore: use assert-job-results action.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,11 +114,6 @@ jobs:
     if: always()
     steps:
       - name: check results
-        run: |
-          FAILURE_JOBS=$(echo "${NEEDS_JSON}" | jq -r 'to_entries | map(select(.value.result != "success")) | map(.key + " " + .value.result) | join("\n")')
-          if [ -n "${FAILURE_JOBS}" ]; then
-            echo "The following jobs failed: ${FAILURE_JOBS}"
-            exit 1
-          fi
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
+        uses: air-hand/common-actions/assert-job-results@9246a4735948c54bb020ddb91786645160c80b4f # v1.0.1
+        with:
+          need-jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -87,11 +87,7 @@ jobs:
     if: always()
     steps:
       - name: check results
-        run: |
-          FAILURE_JOBS=$(echo "${NEEDS_JSON}" | jq -r 'to_entries | map(select(.value.result == "failure")) | map(.key + " " + .value.result) | join("\n")')
-          if [ -n "${FAILURE_JOBS}" ]; then
-            echo "The following jobs failed: ${FAILURE_JOBS}"
-            exit 1
-          fi
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
+        uses: air-hand/common-actions/assert-job-results@9246a4735948c54bb020ddb91786645160c80b4f # v1.0.1
+        with:
+          need-jobs: ${{ toJSON(needs) }}
+          allow-skipped: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD の改善**
	- GitHub Actions ワークフローの `check-ci-result` および `check-tf-result` ジョブを更新
	- 外部アクションを使用してジョブ結果の検証プロセスを簡素化
	- ジョブ失敗の確認方法を、カスタムスクリプトから再利用可能なアクションに変更

<!-- end of auto-generated comment: release notes by coderabbit.ai -->