### PR TITLE
fix/wsl2 nvidia container toolkit

### DIFF
--- a/run_once_setup_wsl2_docker.sh.tmpl
+++ b/run_once_setup_wsl2_docker.sh.tmpl
@@ -69,7 +69,7 @@ else
     # Docker Desktop for Windows
     echo 'running the command below to restart docker desktop on windows host!'
     # In recent versions, the full path to the docker desktop has changed.
-    powershell.exe -Command '$ddPath="C:\Program Files\Docker\frontend\Docker Desktop.exe"; $ddProc=(Get-Process -Name "Docker Desktop" -ErrorAction SilentlyContinue | Select-Object ProcessName,Path -First 1); if ($ddProc) { $ddPath=$ddProc.Path; Stop-Process -Name $ddProc.ProcessName -Force; Wait-Process -Name $ddProc.ProcessName; } Start-Process -FilePath $ddPath; Start-Sleep 10;'
+    powershell.exe -Command '$ddPath="C:\Program Files\Docker\Docker\Docker Desktop.exe"; $ddProc=(Get-Process -Name "Docker Desktop" -ErrorAction SilentlyContinue | Select-Object ProcessName,Path -First 1); if ($ddProc) { $ddPath=$ddProc.Path; Stop-Process -Name $ddProc.ProcessName -Force; Wait-Process -Name $ddProc.ProcessName; } Start-Process -FilePath $ddPath; Start-Sleep 10;'
 fi
 
 # test

--- a/run_once_setup_wsl2_docker.sh.tmpl
+++ b/run_once_setup_wsl2_docker.sh.tmpl
@@ -73,6 +73,6 @@ else
 fi
 
 # test
-docker run --rm --runtime=nvidia --gpus all nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi
+docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.6.3-base-ubuntu24.04 nvidia-smi
 
 {{- end }}

--- a/run_once_setup_wsl2_docker.sh.tmpl
+++ b/run_once_setup_wsl2_docker.sh.tmpl
@@ -42,13 +42,9 @@ EOF
 test ! -f /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg &&
     curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
 
-distribution=$(
-    . /etc/os-release
-    echo $ID$VERSION_ID
-) &&
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list |
-    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' |
-        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 sudo apt update && sudo apt install -y nvidia-container-toolkit
 


### PR DESCRIPTION
- **fix: install nvidia container toolkit on ubuntu 24.04 wsl2.**
- **fix: restart Docker desktop for Windows.**
- **chore: run newest nvidia/cuda container for test.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- NVIDIA コンテナツールキットのソースリストの取得方法を簡素化
	- Docker Desktop for Windows の再起動コマンドを更新
	- CUDA ベースイメージを最新バージョンにアップグレード

- **修正**
	- インストールパスを最新の Docker Desktop パスに調整

これらの変更により、WSL2 環境での Docker と NVIDIA コンテナツールキットのセットアップが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->