### PR TITLE
chore: create symlink .ssh between Windows and WSL2.

### DIFF
--- a/run_once_setup_wsl2.sh.tmpl
+++ b/run_once_setup_wsl2.sh.tmpl
@@ -57,4 +57,14 @@ cat {{ joinPath .chezmoi.sourceDir "files/setup_wsl2_downloads.json" | quote }} 
 
 cd - &>/dev/null
 
+# setup symlink to Windows.
+while read -r target_dir; do
+    if ! test -L ~/${target_dir}; then
+        rm -rf ~/${target_dir}
+    fi
+    ln -s "$(wslpath $(wslvar USERPROFILE))/${target_dir}" ~/${target_dir}
+done << EOF
+.ssh
+EOF
+
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- WSL2環境で`.ssh`ディレクトリのシンボリックリンクを自動的に作成するセットアップスクリプトを追加
	- Windows環境とWSL2環境間でSSHディレクトリを簡単に共有できるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->