### PR TITLE
feat: switch .default-python-packages to pipx backend.

### DIFF
--- a/dot_config/mise/config-global.toml
+++ b/dot_config/mise/config-global.toml
@@ -14,6 +14,13 @@ node = '22'
 "npm:conventional-changelog" = "6.0.0"
 "npm:release-please" = "16.15.0"
 
+# pipx for cli (not library)
+"pipx:pipenv" = "2024.4.1"
+"pipx:poetry" = "2.1.2"
+"pipx:uv" = "0.7.2"
+"pipx:pre-commit" = "4.2.0"
+"pipx:markitdown[all]" = "0.1.1"
+
 [settings]
 experimental = true
 python_compile = true

--- a/dot_default-python-packages
+++ b/dot_default-python-packages
@@ -1,4 +1,2 @@
-# mise python
-pipenv
-poetry
-pre-commit
+# pipx for mise pipx backend https://mise.jdx.dev/dev-tools/backends/pipx.html#pipx-backend
+pipx


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Python CLIツール（pipenv、poetry、uv、pre-commit、markitdown[all]）の新バージョンを利用可能にしました。

- **ドキュメント**
  - Pythonパッケージ管理方法に関する説明を更新し、pipxの利用に一本化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->