### PR TITLE
chore: rename the step on enable-auto-merge.yaml

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -19,7 +19,7 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
       - if: contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor')
-        name: enable auto merge patch version
+        name: enable auto merge minor and patch version
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - GitHub Actionsワークフロー内のステップ名を「パッチバージョンの自動マージ有効化」から「マイナーおよびパッチバージョンの自動マージ有効化」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->