### PR TITLE
chore: remove no install recommends option.

### DIFF
--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -2,11 +2,11 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-sudo -E apt-get update && sudo -E apt-get install -y --no-install-recommends \
+sudo -E apt-get update && sudo -E apt-get install -y  \
     curl \
     bash-completion \
     make \
-    vim vim-common \
+    vim \
     tree \
     socat \
     software-properties-common \
@@ -28,7 +28,7 @@ sudo -E apt-get update && sudo -E apt-get install -y --no-install-recommends \
 {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu") -}}
 sudo add-apt-repository -y ppa:git-core/ppa && sudo  -E apt-get update &&
 {{- end }}
-    sudo -E apt-get install -y --no-install-recommends \
+    sudo -E apt-get install -y \
         git \
         git-lfs \
         tig \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **その他**
  - パッケージインストール時のオプション変更により、推奨パッケージもインストールされるようになりました。
  - インストール対象から `vim-common` を削除し、`vim` のみをインストールするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->