### PR TITLE
Fix super-linter bad object error on closed PRs

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -70,6 +70,7 @@ jobs:
       statuses: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 jobs:
-  call-main:
+  main:
     uses: ./.github/workflows/_main.yaml
     permissions:
       contents: read
@@ -28,25 +28,7 @@ jobs:
       GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
 
   check-result:
-    needs: call-main
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: failure()
-    steps:
-      - name: exit with failure
-        run: exit 1
-
-  check-ci-result:
-    needs: call-main
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: failure()
-    steps:
-      - name: exit with failure
-        run: exit 1
-
-  check-tf-result:
-    needs: call-main
+    needs: main
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: failure()


### PR DESCRIPTION
## Summary
- Skip super-linter execution when PR action is 'closed' to prevent bad object errors
- Clean up redundant workflow jobs (removed check-ci-result, check-tf-result)  
- Rename call-main to main for consistency

## Test plan
- [ ] Verify super-linter no longer runs on closed PRs
- [ ] Confirm workflow still runs properly on open/sync/reopen events

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - GitHub Actionsワークフローで、PRがクローズされた際にsuper-linterジョブが実行されないよう条件を追加しました。
  - ワークフロー内のジョブ名を「call-main」から「main」に変更し、依存関係も更新しました。
  - 冗長な失敗チェック用ジョブ（check-result、check-ci-result）を削除し、ジョブ構成を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->