### PR TITLE
fix: enable lazy install via aqua to reduce github api rate limit.

### DIFF
--- a/run_once_after_install_cli.sh.tmpl
+++ b/run_once_after_install_cli.sh.tmpl
@@ -41,7 +41,7 @@ export PATH=~/.local/share/aquaproj-aqua/bin:$PATH
 # install cli globally by aqua. aqua.yaml hash: {{ include "dot_config/aquaproj-aqua/aqua.yaml" | sha256sum }}
 export AQUA_GLOBAL_CONFIG=$HOME/.config/aquaproj-aqua/aqua.yaml
 aqua update-aqua # update aqua itself
-aqua install --all
+aqua install --all --only-link
 
 # install cli globally by mise. mise/config-global.toml hash: {{ include "dot_config/mise/config-global.toml" | sha256sum }}
 # change default env to avoid using in dev-containers as it may conflict with container tools.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * `aqua` CLIツールのインストール時に `--only-link` オプションを追加し、シンボリックリンクのみを作成する動作に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->