### PR TITLE
feat/aqua disable attestation

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -28,9 +28,7 @@ sourceDir = "{{ env "MY_CHEZMOI_SOURCE" }}"
     git_name = {{ $git_name | quote }}
     git_email = {{ $git_email | quote }}
     git_signingkey = {{ $git_signingkey | quote }}
-    http_proxy = "{{ env "HTTP_PROXY" }}"
-    https_proxy = "{{ env "HTTPS_PROXY" }}"
-    no_proxy = "{{ env "NO_PROXY" }}"
     aqua_disable_github_artifact_attestation = {{ $aqua_disable_github_artifact_attestation }}
     {{/* pass .chezmoi dictionary to template */}}
     {{ includeTemplate "host.toml.tmpl" .chezmoi }}
+    {{ includeTemplate "proxy.toml.tmpl" .chezmoi }}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -10,6 +10,12 @@
 {{ $git_signingkey = promptStringOnce . "git_signingkey" "What is your gpg signingkey for git." }}
 {{- end }}
 
+{{/* skip aqua attestation if needed */}}
+{{ $aqua_disable_github_artifact_attestation := false }}
+{{- if $interactive }}
+{{ $aqua_disable_github_artifact_attestation = promptBoolOnce . "aqua_disable_github_artifact_attestation" "Do you want to disable GitHub artifact attestation." }}
+{{- end }}
+
 {{- if (env "MY_CHEZMOI_SOURCE") }}
 sourceDir = "{{ env "MY_CHEZMOI_SOURCE" }}"
 {{- end }}
@@ -25,5 +31,6 @@ sourceDir = "{{ env "MY_CHEZMOI_SOURCE" }}"
     http_proxy = "{{ env "HTTP_PROXY" }}"
     https_proxy = "{{ env "HTTPS_PROXY" }}"
     no_proxy = "{{ env "NO_PROXY" }}"
+    aqua_disable_github_artifact_attestation = {{ $aqua_disable_github_artifact_attestation }}
     {{/* pass .chezmoi dictionary to template */}}
     {{ includeTemplate "host.toml.tmpl" .chezmoi }}

--- a/.chezmoitemplates/proxy.toml.tmpl
+++ b/.chezmoitemplates/proxy.toml.tmpl
@@ -1,0 +1,3 @@
+http_proxy = "{{ env "HTTP_PROXY" }}"
+https_proxy = "{{ env "HTTPS_PROXY" }}"
+no_proxy = "{{ env "NO_PROXY" }}"

--- a/dot_bash_common_env.tmpl
+++ b/dot_bash_common_env.tmpl
@@ -27,6 +27,7 @@ if test -f ~/.local/share/aquaproj-aqua/bin/aqua && ! command -v aqua &>/dev/nul
     export PATH=~/.local/share/aquaproj-aqua/bin:$PATH
 fi
 export AQUA_GLOBAL_CONFIG=$HOME/.config/aquaproj-aqua/aqua.yaml
+export AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION={{ .aqua_disable_github_artifact_attestation }}
 
 # proxy
 {{- if .http_proxy }}


### PR DESCRIPTION
- **feat: set aqua disable attestation interactively.**
- **chore: move proxy settings to proxy.toml.tmpl**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Aqua の GitHub アーティファクト認証を無効化できるトグルを追加。対話モードでは設定確認のプロンプトを表示。
  - 対応する環境変数を自動エクスポート。

- リファクタ
  - プロキシ設定を専用テンプレートに分離し、環境変数（HTTP_PROXY/HTTPS_PROXY/NO_PROXY）から自動反映。
  - 設定内に「必要に応じて attestation をスキップ」の案内コメントを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->