### PR TITLE
fix: install uv as tools & add openai/codex.

### DIFF
--- a/dot_config/mise/config-global.toml
+++ b/dot_config/mise/config-global.toml
@@ -6,6 +6,7 @@ python = ['3.13.7']
 go = ['1.25.0']
 rust = 'stable'
 node = '22'
+uv = '0.8.14'
 
 "npm:renovate" = "41.91.2"
 "npm:prettier" = "3.6.2"
@@ -14,11 +15,11 @@ node = '22'
 "npm:conventional-changelog" = "7.1.1"
 "npm:release-please" = "17.1.2"
 "npm:@anthropic-ai/claude-code" = "1.0.98"
+"npm:@openai/codex" = "0.27.0"
 
 # pipx for cli (not library)
 "pipx:pipenv" = "2025.0.4"
 "pipx:poetry" = "2.1.4"
-"pipx:uv" = "0.8.14"
 "pipx:pre-commit" = "4.3.0"
 "pipx:markitdown[all]" = "0.1.3"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * 開発環境のツール定義を整理・更新。
  * uv を pipx 管理から標準の tools 管理へ移行（バージョン 0.8.14 に固定）。
  * npm:@openai/codex 0.27.0 を追加し、セットアップの一貫性を向上。
  * 機能・UI の変更はなく、エンドユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->