### PR TITLE
chore(git): ignore .codex globally

### DIFF
--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -1,2 +1,3 @@
 **/.claude/settings.local.json
+**/.codex
 .terragrunt-cache/


### PR DESCRIPTION
## Summary
- add **/.codex to the global git ignore managed by chezmoi

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## チョア
* Git の除外ルールに新しいパターンを追加しました。特定のファイルとディレクトリがバージョン管理から除外されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->