### PR TITLE
Fix Zed terminal PS1 syntax error

### DIFF
--- a/dot_bash_completion.tmpl
+++ b/dot_bash_completion.tmpl
@@ -36,7 +36,8 @@ if [ -f ~/.git-prompt.sh ]; then
     source ~/.git-prompt.sh
 fi
 
-export PS1='[\[\033[32m\]\u\[\033[00m\]:\[\033[33m\]\w\[\033[00m\]]\[\033[36m\]$(__git_ps1 " (%s)")\[\033[00m\]\n\$ '
+PS1='[\[\033[32m\]\u\[\033[00m\]:\[\033[33m\]\w\[\033[00m\]]\[\033[36m\]$(__git_ps1 " (%s)")\[\033[00m\]\n\$ '
+export -n PS1
 
 # gh
 if command -v gh &> /dev/null; then


### PR DESCRIPTION
## Summary
- stop exporting PS1 directly
- unset the export attribute after assigning PS1 to avoid Zed terminal syntax issues

## Test
- bash -n dot_bash_completion.tmpl
- pre-commit hook: make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Bash補完初期化時のPS1プロンプト変数のエクスポート動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->