### PR TITLE
fix: avoid sourcing conda during install

### DIFF
--- a/run_once_install-conda.sh.tmpl
+++ b/run_once_install-conda.sh.tmpl
@@ -10,7 +10,3 @@ sha256sum -c {{ joinPath .chezmoi.sourceDir "files/${MINIFORGE}.checksum" }} || 
 echo "install miniforge"
 bash ${MINIFORGE}.sh -b -u
 cd - &> /dev/null
-
-if ! command -v conda &>/dev/null; then
-    source ~/miniforge3/etc/profile.d/conda.sh
-fi


### PR DESCRIPTION
## Summary
- remove unnecessary conda.sh sourcing after Miniforge installation

## Tests
- chezmoi execute-template < run_once_install-conda.sh.tmpl
- git diff --check
- make test
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Miniforgeのインストール処理を改善しました。ダウンロードと検証後、より確実で効率的なインストール流程を実装しています。インストール処理の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->