### PR TITLE
fix: add dotnet tools to PATH

### DIFF
--- a/dot_bash_common_env.tmpl
+++ b/dot_bash_common_env.tmpl
@@ -11,6 +11,10 @@ if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     export PATH=$HOME/.local/bin:$PATH
 fi
 
+if [[ ":$PATH:" != *":$HOME/.dotnet/tools:"* ]] && [[ -d "$HOME/.dotnet/tools" ]]; then
+    export PATH=$HOME/.dotnet/tools:$PATH
+fi
+
 if [[ ":$PATH:" != *":$HOME/.aspire/bin:"* ]] && [[ -d "$HOME/.aspire/bin" ]]; then
     export PATH=$HOME/.aspire/bin:$PATH
 fi


### PR DESCRIPTION
## Summary
- add $HOME/.dotnet/tools to PATH when the directory exists

## Validation
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `PATH` に `.dotnet/tools` を必要に応じて追加するようになりました。
  * すでに含まれていない場合かつ 해당ディレクトリが存在する場合のみ反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->